### PR TITLE
Removes dangling let clause in crux pull entity-with-prop

### DIFF
--- a/src/main/dv/crux_pull.clj
+++ b/src/main/dv/crux_pull.clj
@@ -312,11 +312,10 @@
   (entity-with-prop [:email \"myaddress@addres.com\"])"
   [db eid]
    (when eid
-     (let [db ]
-       (if (vector? eid)
-         (let [[attr value] eid]
-           (recur db (entity-for-prop db [attr value])))
-         (crux/entity db eid)))))
+     (if (vector? eid)
+       (let [[attr value] eid]
+         (recur db (entity-for-prop db [attr value])))
+       (crux/entity db eid))))
 
 (defn start-entity [db e]
   (if (vector? e)


### PR DESCRIPTION
Removed the dangling ``let`` clause that was left in there after the recent move to expect a Crux database directly as a ``db`` parameter for ``entity-with-prop`` function